### PR TITLE
version deprecation

### DIFF
--- a/pinned.go
+++ b/pinned.go
@@ -15,6 +15,9 @@ var (
 
 	// ErrNoVersionSupplied means no version was supplied.
 	ErrNoVersionSupplied = errors.New("no version supplied")
+
+	// ErrVersionDeprecated means the version is deprecated.
+	ErrVersionDeprecated = errors.New("version is deprecated")
 )
 
 const (
@@ -89,7 +92,14 @@ func (vm *VersionManager) Parse(r *http.Request) (*Version, error) {
 		t = qDate
 	}
 
-	return vm.getVersionByTime(t)
+	v, err := vm.getVersionByTime(t)
+	if err != nil {
+		return nil, err
+	}
+	if v.Deprecated {
+		return v, ErrVersionDeprecated
+	}
+	return v, nil
 }
 
 func (vm *VersionManager) getVersionByTime(t time.Time) (*Version, error) {

--- a/pinned_test.go
+++ b/pinned_test.go
@@ -66,9 +66,10 @@ func TestVersionManagerParse(t *testing.T) {
 	}
 
 	// Should fail if no version supplied.
-	vm.Add(&Version{
+	oldV := &Version{
 		Date: "2017-01-02",
-	})
+	}
+	vm.Add(oldV)
 
 	req := httptest.NewRequest(http.MethodGet, getRoute(""), nil)
 	_, err := vm.Parse(req)
@@ -107,9 +108,10 @@ func TestVersionManagerParse(t *testing.T) {
 	}
 
 	// Should select more recent version if supplied in query params and header.
-	vm.Add(&Version{
+	newV := &Version{
 		Date: "2018-01-02",
-	})
+	}
+	vm.Add(newV)
 
 	req = httptest.NewRequest(http.MethodGet, getRoute("2017-01-02"), nil)
 	req.Header.Set("Version", "2018-01-02")
@@ -119,6 +121,14 @@ func TestVersionManagerParse(t *testing.T) {
 	}
 	if v.Date != "2018-01-02" {
 		t.Fatalf("Expected version 2018-01-02, instead got %s", v.Date)
+	}
+
+	// Should fail if version is deprecated.
+	oldV.Deprecated = true
+	req = httptest.NewRequest(http.MethodGet, getRoute("2017-01-02"), nil)
+	_, err = vm.Parse(req)
+	if err != ErrVersionDeprecated {
+		t.Fatalf("Expected ErrVersionDeprecated, instead got %s", err)
 	}
 }
 

--- a/version.go
+++ b/version.go
@@ -7,8 +7,9 @@ import (
 // Version represents a version change. It is pinned to a specific time.
 // It contains a list of Changes. Changes are executed in-order.
 type Version struct {
-	Date    string
-	Changes []*Change
+	Date       string
+	Changes    []*Change
+	Deprecated bool
 
 	date   time.Time
 	layout string


### PR DESCRIPTION
A version can be marked as `Deprecated`. Now when a client is making a request to a deprecated version, it can be detected easily:

```go
func handler(w http.ResponseWriter, r *http.Request) {
  v, err := vm.Parse(r)
  if err == pinned. ErrVersionDeprecated {
    // Notify client to upgrade.
  }

  // version, v, is not nil.
}