### PR TITLE
add support for context, resolves #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
   // Get version from request.
   v, _ := vm.Parse(r)
 
+  // Set version in context.
+  ctx = pinned.NewContext(r.Context(), v)
+  
   // ...Fetch resources...
 
   // Apply version changes to resources.

--- a/context.go
+++ b/context.go
@@ -1,0 +1,23 @@
+package pinned
+
+import (
+	"context"
+)
+
+// key is unexported and prevents collisions with
+// context keys in other packages.
+type key int
+
+// contextKey is the context key for the Version.
+const contextKey key = 0
+
+// NewContext returns a new Context carrying a Version.
+func NewContext(ctx context.Context, v *Version) context.Context {
+	return context.WithValue(ctx, contextKey, v)
+}
+
+// FromContext returns the Version in the context.
+func FromContext(ctx context.Context) *Version {
+	v, _ := ctx.Value(contextKey).(*Version)
+	return v
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,15 @@
+package pinned
+
+import (
+	"context"
+	"testing"
+)
+
+func TestContext(t *testing.T) {
+	v1 := new(Version)
+	ctx := NewContext(context.Background(), v1)
+	v2 := FromContext(ctx)
+	if v1 != v2 {
+		t.Fatal("Failed to get correct version from context")
+	}
+}


### PR DESCRIPTION
The `Version` can now be included in context that is passed elsewhere. This enables other interactions, like DB/Cache queries, etc. to be aware of what version is requested, in case there is specific handling required.